### PR TITLE
tools: fixed check-imports.py to ignore commented lines

### DIFF
--- a/tools/check-imports.py
+++ b/tools/check-imports.py
@@ -5,10 +5,13 @@ import glob
 import re
 import sys
 
+def check_negative_cases(line, imported):
+  return re.match('using \w+::{0};'.format(imported), line) or re.match('^(\/\/)', line)
+
 
 def do_exist(file_name, lines, imported):
-  if not any(not re.match('using \w+::{0};'.format(imported), line) and
-             re.search(imported, line) for line in lines):
+  if not any(not check_negative_cases(line, imported) and
+             re.search('(\b{0}\b)'.format(imported), line) for line in lines):
     print('File "{0}" does not use "{1}"'.format(file_name, imported))
     return False
   return True

--- a/tools/check-imports.py
+++ b/tools/check-imports.py
@@ -6,12 +6,12 @@ import re
 import sys
 
 def check_negative_cases(line, imported):
-  return re.match('using \w+::{0};'.format(imported), line) or re.match('^(\/\/)', line)
+  return re.match('using \w+::{0};'.format(imported), line) or re.match('^( )*(\t)*(\/\/)', line)
 
 
 def do_exist(file_name, lines, imported):
-  if not any(not check_negative_cases(line, imported) and
-             re.search('(\b{0}\b)'.format(imported), line) for line in lines):
+  if not any((not check_negative_cases(line, imported)) and
+             re.search(r'(\b{0}\b)'.format(imported), line) for line in lines):
     print('File "{0}" does not use "{1}"'.format(file_name, imported))
     return False
   return True
@@ -42,4 +42,4 @@ def is_valid(file_name):
   else:
     return valid
 
-sys.exit(0 if all(map(is_valid, glob.iglob('src/*.cc'))) else 1)
+sys.exit(0 if all(map(is_valid, glob.iglob('../src/*.cc'))) else 1)


### PR DESCRIPTION
The script check-imports.py will now ignore the usage of module names in
commented lines. Additionally, while searching for the usage,
word boundaries will be used. Eg: 'Just' would not be considered in a
sentence containing 'FromJust'.

Fixes: https://github.com/nodejs/node/issues/29226

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
